### PR TITLE
Fix decrepation warnings for Django 1.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-wayf',
-    version='0.3.0',
+    version='0.3.1',
     packages=find_packages(),
     include_package_data=True,
     license='GPL v3',

--- a/urls.py
+++ b/urls.py
@@ -1,12 +1,13 @@
 from django.conf import settings
-from django.conf.urls import patterns, url, include
+from django.conf.urls import url, include
+from django.views.static import serve
 
 urlpatterns = []
 
 
-urlpatterns = patterns('',
-  url(r'^static/(?P<path>.*)$', 'django.views.static.serve',
-      {'document_root': settings.STATIC_ROOT}
-        ),
-)
-urlpatterns += patterns('', (r'^(.*)', include('wayf.urls')))
+urlpatterns = [
+  url(r'^static/(?P<path>.*)$', serve, {
+    'document_root': settings.STATIC_ROOT
+  }),
+]
+urlpatterns += [url(r'^(.*)', include('wayf.urls'))]

--- a/wayf/urls.py
+++ b/wayf/urls.py
@@ -1,9 +1,9 @@
-from django.conf import settings
-from django.conf.urls import patterns, url, include
+from django.conf.urls import url
+from wayf.views import wayf, setlanguage
 
 urlpatterns = []
 
-urlpatterns += patterns('',
-    (r'^/?$', 'wayf.views.wayf'),
-    (r'^setlanguage/(.*)', 'wayf.views.setlanguage'),
-)
+urlpatterns += [
+    url(r'^/?$', wayf),
+    url(r'^setlanguage/(.*)', setlanguage),
+]


### PR DESCRIPTION
`patterns` is deprecated, and url's can't use strings to point to view functions anymore.