### PR TITLE
replace deprecated ifequal

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='django-wayf',
-    version='0.3.8',
+    version='0.3.9',
     packages=find_packages(),
     include_package_data=True,
     license='GPL v3',

--- a/wayf/templates/idp_dropdown.html
+++ b/wayf/templates/idp_dropdown.html
@@ -1,11 +1,11 @@
 	{% for category, insts in  idplist %}
 		<optgroup label="{{ category.name }}">
 		{% for inst in insts %}
-			{% ifequal inst.id selected.id %}
+			{% if inst.id == selected.id %}
 			<option value="{{ inst.id }}" selected="true">{{ inst.name }}</option>
 			{% else %}
 			<option value="{{ inst.id }}">{{ inst.name }}</option>
-			{% endifequal %}
+			{% endif %}
 		{% endfor %}
 		</optgroup>
 	{% endfor %}


### PR DESCRIPTION
ifequal and ifnotequal deprecated since version 3.1.
http://docs.djangoproject.com/en/3.2/ref/templates/builtins/#ifequal-and-ifnotequal
